### PR TITLE
Fix a new warning

### DIFF
--- a/lib/MetamodelX/Red/Relationship.pm6
+++ b/lib/MetamodelX/Red/Relationship.pm6
@@ -75,7 +75,7 @@ multi method add-relationship(::Type Mu:U $self, Red::Attr::Relationship $attr) 
             $attr.package.^rs.new: :filter($ast)
         }
         !! my method (Mu:U:) {
-            if ($*RED-GREP-FILTER ~~ Red::AST).Bool {
+            if ($*RED-GREP-FILTER && $*RED-GREP-FILTER ~~ Red::AST).Bool {
                 $*RED-GREP-FILTER = $attr.relationship-ast
             }
             $attr.has-lazy-relationship ?? $attr.relationship-model !! $attr.type;


### PR DESCRIPTION
After recent changes a new warning appeared in the tests:

```
	WARNING: unhandled Failure detected in DESTROY. If you meant to ignore it, you can mark it as handled by calling .Bool, .so, .not, or .defined methods. The Failure was:
	Dynamic variable $*RED-GREP-FILTER not found
	  in method <anon> at /home/jonathan/devel/perl6/3rdparty-modules/Red/lib/MetamodelX/Red/Relationship.pm6 (MetamodelX::Red::Relationship) line 78
	  in block <unit> at t/02-tdd.t line 257

	WARNING: unhandled Failure detected in DESTROY. If you meant to ignore it, you can mark it as handled by calling .Bool, .so, .not, or .defined methods. The Failure was:
	Dynamic variable $*RED-GREP-FILTER not found
	  in method <anon> at /home/jonathan/devel/perl6/3rdparty-modules/Red/lib/MetamodelX/Red/Relationship.pm6 (MetamodelX::Red::Relationship) line 78
	  in block <unit> at t/02-tdd.t line 236
```

This disarms the failure by explicitly using it in boolean context.