### PR TITLE
Add Duration type.

### DIFF
--- a/lib/Red/Driver/CommonSQL.pm6
+++ b/lib/Red/Driver/CommonSQL.pm6
@@ -335,6 +335,7 @@ multi method translate(Red::AST:U $_, $context?) { Empty, [] }
 multi method default-type-for(Red::Column $ where .attr.type ~~ Rat         --> Str:D) {"real"}
 multi method default-type-for(Red::Column $ where .attr.type ~~ Instant     --> Str:D) {"real"}
 multi method default-type-for(Red::Column $ where .attr.type ~~ DateTime    --> Str:D) {"varchar(32)"}
+multi method default-type-for(Red::Column $ where .attr.type ~~ Duration    --> Str:D) {"interval"}
 multi method default-type-for(Red::Column $ where .attr.type ~~ Mu          --> Str:D) {"varchar(255)"}
 multi method default-type-for(Red::Column $ where .attr.type ~~ Str         --> Str:D) {"varchar(255)"}
 multi method default-type-for(Red::Column $ where .attr.type ~~ Int         --> Str:D) {"integer"}
@@ -344,6 +345,8 @@ multi method default-type-for(Red::Column                                   --> 
 
 multi method inflate(Num $value, Instant  :$to!) { Instant.from-posix: $value }
 multi method inflate(Str $value, DateTime :$to!) { DateTime.new: $value }
+multi method inflate(Num $value, Duration :$to!) { Duration.new: $value }
+multi method inflate(Int $value, Duration :$to!) { Duration.new: $value }
 
 multi method type-by-name("string" --> "varchar(255)") {}
 

--- a/t/12-types.t
+++ b/t/12-types.t
@@ -1,0 +1,28 @@
+use v6;
+use Test;
+
+use Red;
+
+
+my $*RED-DEBUG          = $_ with %*ENV<RED_DEBUG>;
+my $*RED-DEBUG-RESPONSE = $_ with %*ENV<RED_DEBUG_RESPONSE>;
+my $*RED-DB             = database "SQLite", |(:database($_) with %*ENV<RED_DATABASE>);
+
+subtest {
+    model TestDuration {
+        has Int         $.id is serial;
+        has Duration    $.duration is column;
+    }
+
+    lives-ok { TestDuration.^create-table }, "create table with Duration column";
+    my TestDuration $row;
+    lives-ok { $row = TestDuration.^create(duration => Duration.new(10)) }, "create row with Duration";
+    todo "Not yet coercing values from DB";
+    isa-ok $row.duration, Duration;
+}, "test Duration";
+
+
+done-testing;
+# vim: ft=perl6
+
+


### PR DESCRIPTION
Both SQLite and Pg would use "interval" (though it's possible
that they my need to be deflated differently.) SQLite is fine.

Fixes #60