### PR TITLE
Standardise the "use v6" usage

### DIFF
--- a/lib/MetamodelX/Red/Model.pm6
+++ b/lib/MetamodelX/Red/Model.pm6
@@ -1,4 +1,4 @@
-use v6.c;
+use v6;
 use Red::Model;
 use Red::Attr::Column;
 use Red::Column;

--- a/lib/Red.pm6
+++ b/lib/Red.pm6
@@ -1,4 +1,4 @@
-use v6.d.PREVIEW;
+use v6;
 use Red::Model;
 use Red::Attr::Column;
 use Red::Column;


### PR DESCRIPTION
Using "v6.d.PREVIEW" is un-necessary after 2018.12 and simply
using "use v6" will now get us whatever the latest version is.