### PR TITLE
Remove a duplicate "use" from Red::Operators

### DIFF
--- a/lib/Red/Operators.pm6
+++ b/lib/Red/Operators.pm6
@@ -1,5 +1,4 @@
 use Red::AST;
-use Red::AST;
 use Red::AST::Infixes;
 use Red::AST::Value;
 unit module Red::Operators;


### PR DESCRIPTION
I don't think it was doing any harm but the tests are fine without the duplicate :-)