### PR TITLE
Allow creation of Red::Driver from an instance of DB

### DIFF
--- a/lib/Red/Database.pm6
+++ b/lib/Red/Database.pm6
@@ -1,7 +1,15 @@
 use Red::Driver;
 
-sub database(Str $type, |c) is export {
+proto database(|c) is export { * }
+
+multi sub database(Str $type, |c) is export {
     my $driver-name = "Red::Driver::$type";
     require ::($driver-name);
     my Red::Driver $driver = ::($driver-name).new: |c;
+}
+
+multi sub database(Str $type, $dbh) {
+    my $driver-name = "Red::Driver::$type";
+    require ::($driver-name);
+    my Red::Driver $driver = ::($driver-name).new: :$dbh;
 }

--- a/lib/Red/Driver/Pg.pm6
+++ b/lib/Red/Driver/Pg.pm6
@@ -8,10 +8,18 @@ unit class Red::Driver::Pg does Red::Driver::CommonSQL;
 
 has Str $!user;
 has Str $!password;
-has Str $!host = "127.0.0.1";
-has Int $!port = 5432;
+has Str $!host;
+has Int $!port;
 has Str $!dbname;
-has $!dbh = DB::Pg.new: conninfo => "{ "user=$_" with $!user } { "password=$_" with $!password } { "host=$_" with $!host } { "port=$_" with $!port } { "dbname=$_" with $!dbname }";
+has DB::Pg $!dbh;
+
+
+submethod BUILD(DB::Pg :$!dbh, Str :$!user, Str :$!password, Str :$!host = "127.0.0.1", Int :$!port = 5432, Str :$!dbname) {
+}
+
+submethod TWEAK() {
+    $!dbh //= DB::Pg.new: conninfo => "{ "user=$_" with $!user } { "password=$_" with $!password } { "host=$_" with $!host } { "port=$_" with $!port } { "dbname=$_" with $!dbname }";
+}
 
 multi method translate(Red::Column $_, "column-auto-increment") { Empty }
 

--- a/lib/Red/Driver/SQLite.pm6
+++ b/lib/Red/Driver/SQLite.pm6
@@ -1,4 +1,5 @@
 use DBIish;
+need DBDish::SQLite::Connection;
 use Red::AST;
 use Red::Driver;
 use Red::Statement;
@@ -12,7 +13,15 @@ use X::Red::Exceptions;
 unit class Red::Driver::SQLite does Red::Driver::CommonSQL;
 
 has $.database = q<:memory:>;
-has $!dbh = DBIish.connect: "SQLite", :$!database;
+has DBDish::SQLite::Connection $!dbh;
+
+
+submethod BUILD(DBDish::SQLite::Connection :$!dbh, Str :$!database = q<:memory:> ) {
+}
+
+submethod TWEAK() {
+    $!dbh //= DBIish.connect: "SQLite", :$!database;
+}
 
 class Statement does Red::Statement {
     method stt-exec($stt, *@bind) {
@@ -42,22 +51,22 @@ multi method translate(Red::AST::Value $_ where .type ~~ Bool, $context?) {
 }
 
 multi method translate(Red::AST::Not $_ where { .value ~~ Red::Column and .value.attr.type !~~ Str }, $context?) {
-	my $val = self.translate: .value, $context;
+    my $val = self.translate: .value, $context;
     "($val == 0 OR $val IS NULL)"
 }
 
 multi method translate(Red::AST::So $_ where { .value ~~ Red::Column and .value.attr.type !~~ Str }, $context?) {
-	my $val = self.translate: .value, $context;
+    my $val = self.translate: .value, $context;
     "($val <> 0 AND $val IS NOT NULL)"
 }
 
 multi method translate(Red::AST::Not $_ where { .value ~~ Red::Column and .value.attr.type ~~ Str }, $context?) {
-	my $val = self.translate: .value, $context;
+    my $val = self.translate: .value, $context;
     "($val == '' OR $val IS NULL)"
 }
 
 multi method translate(Red::AST::So $_ where { .value ~~ Red::Column and .value.attr.type ~~ Str }, $context?) {
-	my $val = self.translate: .value, $context;
+    my $val = self.translate: .value, $context;
     "($val <> '' AND $val IS NOT NULL)"
 }
 


### PR DESCRIPTION
This allows the user to create the Red::Driver from an already created and connected DBDish or DB::Pg object.
    
The rationale for doing this is to allow for the use of DB specific functionality that may not be exposed by Red.
    
The Pg version I have tested with the code in #94 and it works.
