### PR TITLE
Make .elems return an Int rather than some object

### DIFF
--- a/lib/Red/ResultSeq.pm6
+++ b/lib/Red/ResultSeq.pm6
@@ -255,8 +255,8 @@ multi method head(UInt:D $num) {
     self.do-it(:limit(min $num, $.limit)).head: $num
 }
 
-method elems {
-    self.create-map: Red::AST::Function.new: :func<count>, :args[ast-value *]
+method elems( --> Int) {
+    (self.create-map: Red::AST::Function.new: :func<count>, :args[ast-value *]).Str.Int;
 }
 
 method new-object(::?CLASS:D: *%pars) {


### PR DESCRIPTION
The expectation of the developer is that .elems should return the
number of elements in some collection and be able to compare that
as an integer rather than having an object.

Fixes #97