### PR TITLE
Add suppot for UUID columns in DB::Pg

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -6,7 +6,8 @@
   "build-depends" : [ ],
   "depends" : [
     "DBIish",
-    "DB::Pg"
+    "DB::Pg",
+    "UUID"
   ],
   "description" : "A perl6 ORM",
   "license" : "Artistic-2.0",

--- a/lib/Red/Driver/Pg.pm6
+++ b/lib/Red/Driver/Pg.pm6
@@ -4,6 +4,8 @@ use Red::Driver::CommonSQL;
 use Red::Statement;
 use Red::AST::Infixes;
 use X::Red::Exceptions;
+need UUID;
+
 unit class Red::Driver::Pg does Red::Driver::CommonSQL;
 
 has Str $!user;
@@ -34,6 +36,10 @@ multi method translate(Red::AST::Mod $_, $context?) {
 
 multi method translate(Red::AST::Value $_ where .type ~~ Bool, $context?) {
     .value ?? "'t'" !! "'f'"
+}
+
+multi method translate(Red::AST::Value $_ where .type ~~ UUID, $context?) {
+    "'{ .value.Str }'"
 }
 
 class Statement does Red::Statement {


### PR DESCRIPTION
Postgres has a UUID column type and DB::Pg inflates these as UUID
objects, but when used as a value in a query they are mostly
dealt with as strings.

This provides a value translation for UUID typed columns.

Fixes #102