### PR TITLE
Implement IN in generated SQL

### DIFF
--- a/lib/Red/AST/Infixes.pm6
+++ b/lib/Red/AST/Infixes.pm6
@@ -105,7 +105,7 @@ class Red::AST::AND does Red::AST::Infix {
     has Bool $.returns;
 
     multi method new(Red::AST $left is copy, Red::AST $right is copy) {
-		.return with self.optimize: $left, $right;
+        .return with self.optimize: $left, $right;
 
         $left  .= value if $left ~~ Red::AST::So;
         $right .= value if $right ~~ Red::AST::So;
@@ -239,4 +239,32 @@ class Red::AST::Like does Red::AST::Infix {
     method should-validate {}
 
     multi method new(Red::AST $left, Red::AST::Value $ where .value eq "",  *%) { $left }
+}
+
+class Red::AST::NotIn does Red::AST::Infix {
+    has $.op = "NOT IN";
+    has Str $.returns;
+
+    method should-set(--> Hash()) {
+    }
+
+    method should-validate {}
+
+    method not {
+        Red::AST::In.new: $!left, $!right;
+    }
+}
+
+class Red::AST::In does Red::AST::Infix {
+    has $.op = "IN";
+    has Str $.returns;
+
+    method should-set(--> Hash()) {
+    }
+
+    method should-validate {}
+
+    method not {
+        Red::AST::NotIn.new: $!left, $!right;
+    }
 }

--- a/lib/Red/AST/Select.pm6
+++ b/lib/Red/AST/Select.pm6
@@ -14,7 +14,7 @@ has Int                 $.limit;
 has Red::AST            @.group;
 has                     @.table-list;
 has Red::AST::Comment   @.comments;
-has Bool                $.sub-select is rw;
+has Bool                $.sub-select;
 
 method returns { Red::Model }
 
@@ -44,4 +44,9 @@ method minus($sel) {
     $union.minus: self;
     $union.minus: $sel;
     $union
+}
+
+method as-sub-select {
+    $!sub-select = True;
+    self;
 }

--- a/lib/Red/AST/Select.pm6
+++ b/lib/Red/AST/Select.pm6
@@ -14,10 +14,11 @@ has Int                 $.limit;
 has Red::AST            @.group;
 has                     @.table-list;
 has Red::AST::Comment   @.comments;
+has Bool                $.sub-select is rw;
 
 method returns { Red::Model }
 
-method args { $!of, $!filter, |@!order }
+method args { $!sub-select ?? () !! ( $!of, $!filter, |@!order ) }
 
 method tables(::?CLASS:D:) {
     |($!of, |@!table-list, |(.tables with $!filter), callsame).grep(-> \v { v !=:= Nil }).unique

--- a/lib/Red/Driver/CommonSQL.pm6
+++ b/lib/Red/Driver/CommonSQL.pm6
@@ -119,6 +119,11 @@ multi method translate(Red::AST::Comment $_, $context?) {
 
 method comment-starter { "--" }
 
+multi method translate(Red::AST::Select $ast, 'where') {
+    my ( :$key, :$value ) = self.translate($ast);
+    '( ' ~ $key ~ ' )' => $value // [];
+}
+
 multi method translate(Red::AST::Select $ast, $context?) {
     my @bind;
     my $sel    = do given $ast.of {
@@ -317,6 +322,15 @@ multi method translate(Red::AST::Cast $_, $context?) {
     default {
         self.translate: .value, $context
     }
+}
+
+multi method translate(Red::AST::Value $_ where .type ~~ Red::AST::Select, $context? ) {
+    my ( :$key, :$value ) = self.translate(.value, $context );
+    '( ' ~ $key ~ ' )' => $value ;
+}
+
+multi method translate(Red::AST::Value $_ where .type ~~ Positional, $context?) {
+    '( ' ~ .get-value.map( -> $v { '?' } ).join(', ') ~ ' )' => .get-value;
 }
 
 multi method translate(Red::AST::Value $_ where .type.HOW ~~ Metamodel::EnumHOW, $context?) {

--- a/lib/Red/Operators.pm6
+++ b/lib/Red/Operators.pm6
@@ -306,6 +306,14 @@ multi prefix:<!>(Red::AST $a) is export {
     Red::AST::Not.new: $a
 }
 
+multi prefix:<not>(Red::AST::In $a) is export {
+    $a.not;
+}
+
+multi prefix:<!>(Red::AST::In $a) is export {
+    $a.not;
+}
+
 multi prefix:<so>(Red::AST $a) is export {
     Red::AST::So.new: $a
 }
@@ -342,3 +350,59 @@ multi infix:<⊖>(Red::ResultSeq $a, Red::ResultSeq $b) is export {
 multi infix:<(-)>(Red::ResultSeq $a, Red::ResultSeq $b) is export {
     $a.minus: $b
 }
+
+
+multi infix:<in>(Red::AST $a, @b where  { $_ !~~ Red::ResultSeq } ) is export {
+    Red::AST::In.new: $a, ast-value(@b);
+}
+
+multi infix:<⊂>(Red::AST $a, @b where  { $_ !~~ Red::ResultSeq } ) is export {
+    Red::AST::In.new: $a, ast-value(@b);
+}
+multi infix:«(<)»(Red::AST $a, @b where  { $_ !~~ Red::ResultSeq } ) is export {
+    Red::AST::In.new: $a, ast-value(@b);
+}
+
+multi infix:<⊃>(Red::AST $a, @b where  { $_ !~~ Red::ResultSeq } ) is export {
+    Red::AST::NotIn.new: $a, ast-value(@b);
+}
+multi infix:«(>)»(Red::AST $a, @b where  { $_ !~~ Red::ResultSeq } ) is export {
+    Red::AST::NotIn.new: $a, ast-value(@b);
+}
+
+multi infix:<in>(Red::AST $a, Red::ResultSeq $b ) is export {
+    Red::AST::In.new: $a, ast-value($b.ast);
+}
+
+multi infix:<⊂>(Red::AST $a, Red::ResultSeq $b ) is export {
+    Red::AST::In.new: $a, ast-value($b.ast);
+}
+multi infix:«(<)»(Red::AST $a, Red::ResultSeq $b ) is export {
+    Red::AST::In.new: $a, ast-value($b.ast);
+}
+
+multi infix:<⊃>(Red::AST $a, Red::ResultSeq $b ) is export {
+    Red::AST::NotIn.new: $a, ast-value($b.ast);
+}
+multi infix:«(>)»(Red::AST $a, Red::ResultSeq $b ) is export {
+    Red::AST::NotIn.new: $a, ast-value($b.ast);
+}
+
+multi infix:<in>(Red::AST $a, Red::AST::Select $b ) is export {
+    Red::AST::In.new: $a, ast-value($b);
+}
+
+multi infix:<⊂>(Red::AST $a, Red::AST::Select $b ) is export {
+    Red::AST::In.new: $a, ast-value($b);
+}
+multi infix:«(<)»(Red::AST $a, Red::AST::Select $b ) is export {
+    Red::AST::In.new: $a, ast-value($b);
+}
+
+multi infix:<⊃>(Red::AST $a, Red::AST::Select $b ) is export {
+    Red::AST::NotIn.new: $a, ast-value($b);
+}
+multi infix:«(>)»(Red::AST $a, Red::AST::Select $b ) is export {
+    Red::AST::NotIn.new: $a, ast-value($b);
+}
+

--- a/lib/Red/Operators.pm6
+++ b/lib/Red/Operators.pm6
@@ -392,25 +392,20 @@ multi infix:«(>)»(Red::AST $a, PositionalNotResultSeq $b ) is export {
 
 
 multi infix:<in>(Red::AST $a, Red::AST::Select $b ) is export {
-    $b.sub-select = True;
-    Red::AST::In.new: $a, $b;
+    Red::AST::In.new: $a, $b.as-sub-select;
 }
 
 multi infix:<⊂>(Red::AST $a, Red::AST::Select $b ) is export {
-    $b.sub-select = True;
-    Red::AST::In.new: $a, $b;
+    Red::AST::In.new: $a, $b.as-sub-select;
 }
 multi infix:«(<)»(Red::AST $a, Red::AST::Select $b ) is export {
-    $b.sub-select = True;
-    Red::AST::In.new: $a, $b;
+    Red::AST::In.new: $a, $b.as-sub-select;
 }
 
 multi infix:<⊃>(Red::AST $a, Red::AST::Select $b ) is export {
-    $b.sub-select = True;
-    Red::AST::NotIn.new: $a, $b;
+    Red::AST::NotIn.new: $a, $b.as-sub-select;
 }
 multi infix:«(>)»(Red::AST $a, Red::AST::Select $b ) is export {
-    $b.sub-select = True;
-    Red::AST::NotIn.new: $a, $b;
+    Red::AST::NotIn.new: $a, $b.as-sub-select;
 }
 

--- a/lib/Red/Operators.pm6
+++ b/lib/Red/Operators.pm6
@@ -353,21 +353,21 @@ multi infix:<(-)>(Red::ResultSeq $a, Red::ResultSeq $b) is export {
 
 
 multi infix:<in>(Red::AST $a, Red::ResultSeq:D $b ) is export is default {
-    Red::AST::In.new: $a, ast-value($b.ast);
+    Red::AST::In.new: $a, $b.ast(:sub-select);
 }
 
 multi infix:<⊂>(Red::AST $a, Red::ResultSeq $b ) is export is default {
-    Red::AST::In.new: $a, ast-value($b.ast);
+    Red::AST::In.new: $a, $b.ast(:sub-select);
 }
 multi infix:«(<)»(Red::AST $a, Red::ResultSeq $b ) is export is default {
-    Red::AST::In.new: $a, ast-value($b.ast);
+    Red::AST::In.new: $a, $b.ast(:sub-select);
 }
 
 multi infix:<⊃>(Red::AST $a, Red::ResultSeq $b ) is export is default {
-    Red::AST::NotIn.new: $a, ast-value($b.ast);
+    Red::AST::NotIn.new: $a, $b.ast(:sub-select);
 }
 multi infix:«(>)»(Red::AST $a, Red::ResultSeq $b ) is export is default {
-    Red::AST::NotIn.new: $a, ast-value($b.ast);
+    Red::AST::NotIn.new: $a, $b.ast(:sub-select);
 }
 
 subset PositionalNotResultSeq of Any  where { $_ ~~ Positional && $_ !~~ Red::ResultSeq };
@@ -392,20 +392,25 @@ multi infix:«(>)»(Red::AST $a, PositionalNotResultSeq $b ) is export {
 
 
 multi infix:<in>(Red::AST $a, Red::AST::Select $b ) is export {
-    Red::AST::In.new: $a, ast-value($b);
+    $b.sub-select = True;
+    Red::AST::In.new: $a, $b;
 }
 
 multi infix:<⊂>(Red::AST $a, Red::AST::Select $b ) is export {
-    Red::AST::In.new: $a, ast-value($b);
+    $b.sub-select = True;
+    Red::AST::In.new: $a, $b;
 }
 multi infix:«(<)»(Red::AST $a, Red::AST::Select $b ) is export {
-    Red::AST::In.new: $a, ast-value($b);
+    $b.sub-select = True;
+    Red::AST::In.new: $a, $b;
 }
 
 multi infix:<⊃>(Red::AST $a, Red::AST::Select $b ) is export {
-    Red::AST::NotIn.new: $a, ast-value($b);
+    $b.sub-select = True;
+    Red::AST::NotIn.new: $a, $b;
 }
 multi infix:«(>)»(Red::AST $a, Red::AST::Select $b ) is export {
-    Red::AST::NotIn.new: $a, ast-value($b);
+    $b.sub-select = True;
+    Red::AST::NotIn.new: $a, $b;
 }
 

--- a/lib/Red/Operators.pm6
+++ b/lib/Red/Operators.pm6
@@ -352,41 +352,44 @@ multi infix:<(-)>(Red::ResultSeq $a, Red::ResultSeq $b) is export {
 }
 
 
-multi infix:<in>(Red::AST $a, @b where  { $_ !~~ Red::ResultSeq } ) is export {
-    Red::AST::In.new: $a, ast-value(@b);
-}
-
-multi infix:<⊂>(Red::AST $a, @b where  { $_ !~~ Red::ResultSeq } ) is export {
-    Red::AST::In.new: $a, ast-value(@b);
-}
-multi infix:«(<)»(Red::AST $a, @b where  { $_ !~~ Red::ResultSeq } ) is export {
-    Red::AST::In.new: $a, ast-value(@b);
-}
-
-multi infix:<⊃>(Red::AST $a, @b where  { $_ !~~ Red::ResultSeq } ) is export {
-    Red::AST::NotIn.new: $a, ast-value(@b);
-}
-multi infix:«(>)»(Red::AST $a, @b where  { $_ !~~ Red::ResultSeq } ) is export {
-    Red::AST::NotIn.new: $a, ast-value(@b);
-}
-
-multi infix:<in>(Red::AST $a, Red::ResultSeq $b ) is export {
+multi infix:<in>(Red::AST $a, Red::ResultSeq:D $b ) is export is default {
     Red::AST::In.new: $a, ast-value($b.ast);
 }
 
-multi infix:<⊂>(Red::AST $a, Red::ResultSeq $b ) is export {
+multi infix:<⊂>(Red::AST $a, Red::ResultSeq $b ) is export is default {
     Red::AST::In.new: $a, ast-value($b.ast);
 }
-multi infix:«(<)»(Red::AST $a, Red::ResultSeq $b ) is export {
+multi infix:«(<)»(Red::AST $a, Red::ResultSeq $b ) is export is default {
     Red::AST::In.new: $a, ast-value($b.ast);
 }
 
-multi infix:<⊃>(Red::AST $a, Red::ResultSeq $b ) is export {
+multi infix:<⊃>(Red::AST $a, Red::ResultSeq $b ) is export is default {
     Red::AST::NotIn.new: $a, ast-value($b.ast);
 }
-multi infix:«(>)»(Red::AST $a, Red::ResultSeq $b ) is export {
+multi infix:«(>)»(Red::AST $a, Red::ResultSeq $b ) is export is default {
     Red::AST::NotIn.new: $a, ast-value($b.ast);
 }
+
+subset PositionalNotResultSeq of Any  where { $_ ~~ Positional && $_ !~~ Red::ResultSeq };
+
+multi infix:<in>(Red::AST $a, PositionalNotResultSeq $b ) is export {
+    Red::AST::In.new: $a, ast-value($b);
+}
+
+multi infix:<⊂>(Red::AST $a, PositionalNotResultSeq $b ) is export {
+    Red::AST::In.new: $a, ast-value($b);
+}
+multi infix:«(<)»(Red::AST $a, PositionalNotResultSeq $b ) is export {
+    Red::AST::In.new: $a, ast-value($b);
+}
+
+multi infix:<⊃>(Red::AST $a, PositionalNotResultSeq $b ) is export {
+    Red::AST::NotIn.new: $a, ast-value($b);
+}
+multi infix:«(>)»(Red::AST $a, PositionalNotResultSeq $b ) is export {
+    Red::AST::NotIn.new: $a, ast-value($b);
+}
+
 
 multi infix:<in>(Red::AST $a, Red::AST::Select $b ) is export {
     Red::AST::In.new: $a, ast-value($b);

--- a/lib/Red/ResultSeq.pm6
+++ b/lib/Red/ResultSeq.pm6
@@ -192,11 +192,11 @@ multi method create-map(Red::Model  $_, :filter(&)) is hidden-from-sql-commentin
 multi method create-map(*@ret where .all ~~ Red::AST, :filter(&)) is hidden-from-sql-commenting {
     my \Meta  = self.of.HOW.WHAT;
     my \model = Meta.new(:table(self.of.^table)).new_type: :name(self.of.^name);
-	model.HOW.^attributes.first(*.name eq '$!table').set_value: model.HOW, self.of.^table;
-	my $attr-name = 'data_0';
+    model.HOW.^attributes.first(*.name eq '$!table').set_value: model.HOW, self.of.^table;
+    my $attr-name = 'data_0';
     my @attrs = do for @ret {
-		my $name = $.filter ~~ Red::AST::MultiSelect ?? .attr.name.substr(2) !! ++$attr-name;
-		my $col-name = $_ ~~ Red::Column ?? .attr.name.substr(2) !! $name;
+        my $name = $.filter ~~ Red::AST::MultiSelect ?? .attr.name.substr(2) !! ++$attr-name;
+        my $col-name = $_ ~~ Red::Column ?? .attr.name.substr(2) !! $name;
         my $attr  = Attribute.new:
             :name("\$!$name"),
             :package(model),
@@ -204,26 +204,26 @@ multi method create-map(*@ret where .all ~~ Red::AST, :filter(&)) is hidden-from
             :has_accessor,
             :build(.returns),
         ;
-	    my %data = %(
-	        :name-alias($col-name),
-	        :name($col-name),
-	        :attr-name($name),
-	        :type(.returns.^name),
-	        :$attr,
-	        :class(model),
-			|(do if $_ ~~ Red::Column {
-				:inflate(.inflate),
-				:deflate(.deflate),
-			} else {
-	        	:computation($_)
-			})
-	    );
-	    $attr does Red::Attr::Column(%data);
+        my %data = %(
+            :name-alias($col-name),
+            :name($col-name),
+            :attr-name($name),
+            :type(.returns.^name),
+            :$attr,
+            :class(model),
+        	|(do if $_ ~~ Red::Column {
+        		:inflate(.inflate),
+        		:deflate(.deflate),
+        	} else {
+                :computation($_)
+        	})
+        );
+        $attr does Red::Attr::Column(%data);
         model.^add_attribute: $attr;
-		model.^add_multi_method: $name, my method (Mu:D:) { self.get_value: "\$!$name" }
+        model.^add_multi_method: $name, my method (Mu:D:) { self.get_value: "\$!$name" }
         $attr
     }
-	model.^add_method: "no-table", my method no-table { True }
+    model.^add_method: "no-table", my method no-table { True }
     model.^compose;
     model.^add-column: $_ for @attrs;
     self.clone(
@@ -335,10 +335,10 @@ method minus(::?CLASS:D: $other) is hidden-from-sql-commenting {
     self.clone: :chain($!chain.clone: :$filter)
 }
 
-method ast is hidden-from-sql-commenting {
+method ast(Bool :$sub-select) is hidden-from-sql-commenting {
     if $.filter ~~ Red::AST::MultiSelect {
         $.filter
     } else {
-        Red::AST::Select.new: :$.of, :$.filter, :$.limit, :@.order, :@.table-list, :@.group, :@.comments;
+        Red::AST::Select.new: :$.of, :$.filter, :$.limit, :@.order, :@.table-list, :@.group, :@.comments, :$sub-select;
     }
 }

--- a/t/20-in-sql.t
+++ b/t/20-in-sql.t
@@ -1,0 +1,41 @@
+use Red;
+use Test;
+
+model Foo is rw {
+    has Int $.id    is serial;
+    has Str $.name  is column;
+}
+
+my $*RED-DEBUG          = $_ with %*ENV<RED_DEBUG>;
+my $*RED-DB             = database "SQLite", |(:database($_) with %*ENV<RED_DATABASE>);
+
+Foo.^create-table;
+
+my @foos;
+for <a b c d> -> $name {
+    @foos.append: Foo.^create(:$name);
+}
+
+is-deeply Foo.^rs.grep(*.name in <b c>).Seq, (@foos[1], @foos[2]), "in with literal list";
+is-deeply Foo.^rs.grep(*.name (<) <b c>).Seq, (@foos[1], @foos[2]), "in with literal list with (<) operator";
+is-deeply Foo.^rs.grep(*.name ⊂ <b c>).Seq, (@foos[1], @foos[2]), "in with literal list with ⊂";
+
+is-deeply Foo.^rs.grep(not *.name in <b c>).Seq, ( @foos[0], @foos[3]), "not in with literal list";
+is-deeply Foo.^rs.grep(not *.name (<) <b c>).Seq, ( @foos[0], @foos[3]), "not in with literal list with (<) operator";
+is-deeply Foo.^rs.grep(not *.name ⊂ <b c>).Seq, ( @foos[0], @foos[3]), "not in with literal list with ⊂ operator";
+is-deeply Foo.^rs.grep(*.name ⊃ <b c>).Seq, ( @foos[0], @foos[3]), "not in with literal list with ⊃ operator";
+is-deeply Foo.^rs.grep( *.name (>) <b c>).Seq, ( @foos[0], @foos[3]), "not in with literal list with (>) operator";
+
+
+is-deeply Foo.^rs.grep( *.id in Foo.^rs.grep( { .name ne 'b' } ).map({ .id }).ast  ).Seq, ( @foos[0], @foos[2], @foos[3]), "in with resultset";
+is-deeply Foo.^rs.grep( *.id (<) Foo.^rs.grep( { .name ne 'b' } ).map({ .id }).ast  ).Seq, ( @foos[0], @foos[2], @foos[3]), "in with resultset with (<) operator ";
+is-deeply Foo.^rs.grep( *.id ⊂ Foo.^rs.grep( { .name ne 'b' } ).map({ .id }).ast  ).Seq, ( @foos[0], @foos[2], @foos[3]), "in with resultset with ⊂ operator";
+
+is-deeply Foo.^rs.grep( not *.id in Foo.^rs.grep( { .name ne 'b' } ).map({ .id }).ast  ).Seq, ( @foos[1],  ), "not in with resultset";
+is-deeply Foo.^rs.grep( not *.id (<) Foo.^rs.grep( { .name ne 'b' } ).map({ .id }).ast  ).Seq, ( @foos[1],  ), "not in with resultset with (<) operator";
+is-deeply Foo.^rs.grep( not *.id ⊂ Foo.^rs.grep( { .name ne 'b' } ).map({ .id }).ast  ).Seq, ( @foos[1],  ), "not in with resultset with ⊂ operator";
+is-deeply Foo.^rs.grep( *.id (>) Foo.^rs.grep( { .name ne 'b' } ).map({ .id }).ast  ).Seq, ( @foos[1],  ), "not in with resultset with (>) operator";
+is-deeply Foo.^rs.grep( *.id ⊃ Foo.^rs.grep( { .name ne 'b' } ).map({ .id }).ast  ).Seq, ( @foos[1],  ), "not in with resultset with ⊃ operator";
+
+done-testing;
+# vim: ft=perl6

--- a/t/20-in-sql.t
+++ b/t/20-in-sql.t
@@ -27,15 +27,27 @@ is-deeply Foo.^rs.grep(*.name ⊃ <b c>).Seq, ( @foos[0], @foos[3]), "not in wit
 is-deeply Foo.^rs.grep( *.name (>) <b c>).Seq, ( @foos[0], @foos[3]), "not in with literal list with (>) operator";
 
 
-is-deeply Foo.^rs.grep( *.id in Foo.^rs.grep( { .name ne 'b' } ).map({ .id }).ast  ).Seq, ( @foos[0], @foos[2], @foos[3]), "in with resultset";
-is-deeply Foo.^rs.grep( *.id (<) Foo.^rs.grep( { .name ne 'b' } ).map({ .id }).ast  ).Seq, ( @foos[0], @foos[2], @foos[3]), "in with resultset with (<) operator ";
-is-deeply Foo.^rs.grep( *.id ⊂ Foo.^rs.grep( { .name ne 'b' } ).map({ .id }).ast  ).Seq, ( @foos[0], @foos[2], @foos[3]), "in with resultset with ⊂ operator";
+# Raw RS
+is-deeply Foo.^rs.grep( *.id in Foo.^rs.grep( { .name ne 'b' } ).map({ .id })  ).Seq, ( @foos[0], @foos[2], @foos[3]), "in with resultset";
+is-deeply Foo.^rs.grep( *.id (<) Foo.^rs.grep( { .name ne 'b' } ).map({ .id })  ).Seq, ( @foos[0], @foos[2], @foos[3]), "in with resultset with (<) operator ";
+is-deeply Foo.^rs.grep( *.id ⊂ Foo.^rs.grep( { .name ne 'b' } ).map({ .id })  ).Seq, ( @foos[0], @foos[2], @foos[3]), "in with resultset with ⊂ operator";
 
-is-deeply Foo.^rs.grep( not *.id in Foo.^rs.grep( { .name ne 'b' } ).map({ .id }).ast  ).Seq, ( @foos[1],  ), "not in with resultset";
-is-deeply Foo.^rs.grep( not *.id (<) Foo.^rs.grep( { .name ne 'b' } ).map({ .id }).ast  ).Seq, ( @foos[1],  ), "not in with resultset with (<) operator";
-is-deeply Foo.^rs.grep( not *.id ⊂ Foo.^rs.grep( { .name ne 'b' } ).map({ .id }).ast  ).Seq, ( @foos[1],  ), "not in with resultset with ⊂ operator";
-is-deeply Foo.^rs.grep( *.id (>) Foo.^rs.grep( { .name ne 'b' } ).map({ .id }).ast  ).Seq, ( @foos[1],  ), "not in with resultset with (>) operator";
-is-deeply Foo.^rs.grep( *.id ⊃ Foo.^rs.grep( { .name ne 'b' } ).map({ .id }).ast  ).Seq, ( @foos[1],  ), "not in with resultset with ⊃ operator";
+is-deeply Foo.^rs.grep( not *.id in Foo.^rs.grep( { .name ne 'b' } ).map({ .id })  ).Seq, ( @foos[1],  ), "not in with resultset";
+is-deeply Foo.^rs.grep( not *.id (<) Foo.^rs.grep( { .name ne 'b' } ).map({ .id })  ).Seq, ( @foos[1],  ), "not in with resultset with (<) operator";
+is-deeply Foo.^rs.grep( not *.id ⊂ Foo.^rs.grep( { .name ne 'b' } ).map({ .id })  ).Seq, ( @foos[1],  ), "not in with resultset with ⊂ operator";
+is-deeply Foo.^rs.grep( *.id (>) Foo.^rs.grep( { .name ne 'b' } ).map({ .id })  ).Seq, ( @foos[1],  ), "not in with resultset with (>) operator";
+is-deeply Foo.^rs.grep( *.id ⊃ Foo.^rs.grep( { .name ne 'b' } ).map({ .id })  ).Seq, ( @foos[1],  ), "not in with resultset with ⊃ operator";
+
+# AST
+is-deeply Foo.^rs.grep( *.id in Foo.^rs.grep( { .name ne 'b' } ).map({ .id }).ast  ).Seq, ( @foos[0], @foos[2], @foos[3]), "in with resultset AST ";
+is-deeply Foo.^rs.grep( *.id (<) Foo.^rs.grep( { .name ne 'b' } ).map({ .id }).ast  ).Seq, ( @foos[0], @foos[2], @foos[3]), "in with resultset  AST with (<) operator ";
+is-deeply Foo.^rs.grep( *.id ⊂ Foo.^rs.grep( { .name ne 'b' } ).map({ .id }).ast  ).Seq, ( @foos[0], @foos[2], @foos[3]), "in with resultset  AST with ⊂ operator";
+
+is-deeply Foo.^rs.grep( not *.id in Foo.^rs.grep( { .name ne 'b' } ).map({ .id }).ast  ).Seq, ( @foos[1],  ), "not in with resultset AST ";
+is-deeply Foo.^rs.grep( not *.id (<) Foo.^rs.grep( { .name ne 'b' } ).map({ .id }).ast  ).Seq, ( @foos[1],  ), "not in with resultset  AST with (<) operator";
+is-deeply Foo.^rs.grep( not *.id ⊂ Foo.^rs.grep( { .name ne 'b' } ).map({ .id }).ast  ).Seq, ( @foos[1],  ), "not in with resultset  AST with ⊂ operator";
+is-deeply Foo.^rs.grep( *.id (>) Foo.^rs.grep( { .name ne 'b' } ).map({ .id }).ast  ).Seq, ( @foos[1],  ), "not in with resultset  AST with (>) operator";
+is-deeply Foo.^rs.grep( *.id ⊃ Foo.^rs.grep( { .name ne 'b' } ).map({ .id }).ast  ).Seq, ( @foos[1],  ), "not in with resultset  AST with ⊃ operator";
 
 done-testing;
 # vim: ft=perl6


### PR DESCRIPTION
This implements an 'in', '⊂', '(<)' operators for IN and '⊃' and '(>)'
for 'NOT IN' (also allowing negation of IN).

The ResultSeq on the RHS doesn't quite work without being made into an
AST as it appears to expand the result in the operator subroutine,

This mostly implements https://github.com/FCO/Red/issues/87