### PR TITLE
Add 'unless-exists' alias for 'if-not-exists'

### DIFF
--- a/lib/MetamodelX/Red/Model.pm6
+++ b/lib/MetamodelX/Red/Model.pm6
@@ -207,7 +207,7 @@ method all($obj)                    { $obj.^rs }
 
 method temp(|) is rw { $!temporary }
 
-multi method create-table(\model, Bool :$if-not-exists where * === True) {
+multi method create-table(\model, Bool :unless-exists(:$if-not-exists) where ? *) {
     CATCH { when X::Red::Driver::Mapped::TableExists {
         return False
     }}


### PR DESCRIPTION
Caught myself typing 'unless' very often. Decided that'd be a good
alternative.

Also shortened the 'where' condition.