### PR TITLE
Minor edits to Architecture docs

### DIFF
--- a/docs/tutorials/architecture.md
+++ b/docs/tutorials/architecture.md
@@ -4,8 +4,9 @@
 For doing that [Red](https://github.com/FCO/Red) implements a custom Metamodel based on [Metamodel::ClassHOW](https://docs.raku.org/type/Metamodel::ClassHOW).
 To use that, you can use the `model` keyword to describe your table and it's relations as a Raku class.
 
-The Red Metamodel exports a meta-method called `all` or `rs` and it returns an instance of a class called `Red::ResultSeq` that should be seen as a expecialization
-of the `Seq` raku's type but it's data is on the database. So `MyModel.^all` represents all rows on the table represented by `MyModel`, and
-`MyModel.^all.grep: *.col1 > 3` represents all rows on the table represented by `MyModel` where the value of `col1` is higher than 3. The `grep` method (as most of
-the other ResultSeq methods) returns a new ResultSeq.
+The Red Metamodel exports a meta-method called `all` or `rs`, which returns an instance of a class called `Red::ResultSeq`. `ResultSeq` is essentially a 
+specialization  of Raku’s `Seq` type for data is on the database. So `MyModel.^all` represents all rows on the `MyModel` table, and 
+`MyModel.^all.grep: *.col1 > 3` represents all rows on the `MyModel` table where the value of `col1` is higher than 3. The `grep` method (and most of the other 
+`ResultSeq` methods) returns a new `ResultSeq`.
+
 


### PR DESCRIPTION
A few minor suggestions, as discussed on IRC.

One note, I wasn't entirely sure what this sentence meant: "The Red Metamodel exports a meta-method called `all` or `rs` and it returns an instance of a class called `Red::ResultSeq`".  I read that as saying that the *method* returns the class and revised to clarify that meaning – but if the module returns the class, my revision is incorrect.