### PR TITLE
make copy of table name in `is table<>`

### DIFF
--- a/lib/Red/Traits.pm6
+++ b/lib/Red/Traits.pm6
@@ -89,7 +89,7 @@ multi trait_mod:<is>(Attribute $attr, :$referencing! (Str :$model!, Str :$column
 #| This trait allows setting a custom name for a table corresponding to a model.
 #| For example, `model MyModel is table<custom_table_name> {}` will use `custom_table_name`
 #| as the name of the underlying database table.
-multi trait_mod:<is>(Mu:U $model, Str :$table! where .chars > 0 --> Empty) {
+multi trait_mod:<is>(Mu:U $model, Str :$table! is copy where .chars > 0 --> Empty) {
     $model.HOW.^attributes.first({ .name eq '$!table' }).set_value($model.HOW, $table)
 }
 

--- a/t/24-metamodel-model.t
+++ b/t/24-metamodel-model.t
@@ -133,6 +133,10 @@ is-deeply $bla.^id-map(42), { :42id, };
 # TODO
 #say IsId.^filter-id: 42;
 
+{
+    temp Bla.^table = "temp_bla";
+    is Bla.^table, "temp_bla";
+}
 
 is Bla.^table, "bla";
 Bla.^table = "not_bla";


### PR DESCRIPTION
If we don't $table value copied, raku will bind the Str passed directly,
Which fails `temp Model.^table = "new-name"` with error "Can only use 'temp' on a container"
and `Model.^table ="new-name"` with error " Cannot modify an immutable Str(table_name)"