### PR TITLE
Fix use of experimentals in pre-compiled modules

### DIFF
--- a/lib/MetamodelX/Red/Model.pm6
+++ b/lib/MetamodelX/Red/Model.pm6
@@ -120,6 +120,14 @@ method set-helper-attrs(Mu \type) {
     self.MetamodelX::Red::Id::set-helper-attrs(type);
 }
 
+method new(|c) {
+    my @eroles = @Red::experimental-roles.grep(self !~~ *).sort({ $^a.^name cmp $^b.^name});
+    if +@eroles {
+        return (self.^mixin: |@eroles).new(|c)
+    }
+    nextsame
+}
+
 #| Compose
 method compose(Mu \type) {
     self.set-helper-attrs: type;

--- a/lib/Red.pm6
+++ b/lib/Red.pm6
@@ -24,6 +24,7 @@ use Red::AST::Infixes;
 
 class Red:ver<0.1.31>:api<2> {
     our %experimentals;
+    our @experimental-roles;
     method events   { Red::Class.instance.events }
     method emit(|c) { get-RED-DB.emit: |c        }
     method experimentals { %experimentals }
@@ -70,9 +71,8 @@ multi experimental($ where "experimental migrations" | "migrations") {
 }
 
 multi experimental("supply") {
-    use MetamodelX::Red::Supply;
-    MetamodelX::Red::Model.^add_role: MetamodelX::Red::Supply;
-    MetamodelX::Red::Model.^compose;
+    require ::('MetamodelX::Red::Supply');
+    @Red::experimental-roles.push: ::('MetamodelX::Red::Supply');
 
     Empty
 }
@@ -94,9 +94,8 @@ multi experimental("has-one") {
 }
 
 multi experimental("refreshable") {
-    use MetamodelX::Red::Refreshable;
-    MetamodelX::Red::Model.^add_role: MetamodelX::Red::Refreshable;
-    MetamodelX::Red::Model.^compose;
+    require ::('MetamodelX::Red::Refreshable');
+    @Red::experimental-roles.push: ::('MetamodelX::Red::Refreshable');
 
     Empty
 }


### PR DESCRIPTION
Mixin experimental roles into `MetmodelX::Red::Model` in its `new`
constructor when needed and create a new instance out of the mixin
class.