### PR TITLE
Don't do aliasing unless isn't done yet

### DIFF
--- a/lib/MetamodelX/Red/Model.pm6
+++ b/lib/MetamodelX/Red/Model.pm6
@@ -52,6 +52,7 @@ has @!constraints;
 has $.table;
 has Bool $!temporary;
 has Bool $!default-null;
+has %!alias-cache;
 
 multi method emit(Mu $model, Red::Event $event) {
     start try get-RED-DB.emit: $event.clone: :model($model.WHAT)
@@ -214,8 +215,10 @@ multi method join(\model, \to-join, $on where *.^can("relationship-ast"), :$name
 }
 
 my UInt $alias_num = 1;
-method alias(Red::Model:U \type, Str $name = "{type.^name}_{$alias_num++}", :$base, :$relationship, :$join-type) {
+method alias(|c (Red::Model:U \type, Str $name = "{type.^name}_{$alias_num++}", :$base, :$relationship, :$join-type)) {
+    return %!alias-cache{$name} if %!alias-cache{$name}:exists;
     my \alias = ::?CLASS.new_type(:$name);
+    %!alias-cache{$name} := alias;
     my role RAlias[Red::Model:U \rtype, Str $rname, \alias, \rel, \base, \join-type, @cols] {
         method columns(|)     { @cols }
         method table(|)       { rtype.^table }


### PR DESCRIPTION
This optimization is based on assumption that alias class name passed in
`:name` to method `alias` of `MetamodelX::Red::Model` unambigously
defines the class' typeobject. So, instead of re-aliasing on every
method call, `alias` records the class in a cache and re-uses when a
class of the same name is requested.

Hopefully, the approach is ok because caching is done per-model, so name
clashing should happen.