### PR TITLE
Fix create with more than one positional attribute

### DIFF
--- a/lib/MetamodelX/Red/Model.pm6
+++ b/lib/MetamodelX/Red/Model.pm6
@@ -501,8 +501,9 @@ multi method create(\model, *%orig-pars, :$with where not .defined) is rw {
                 .reduce: { Red::AST::AND.new: $^a, $^b }
         }
 
+        my $no;
         for %positionals.kv -> $name, @val {
-            FIRST my $no = model.^find($filter);
+            FIRST $no = model.^find($filter);
             $no."$name"().create: |$_ for @val
         }
         self.apply-row-phasers($obj, AfterCreate);

--- a/t/10-alternate-relation-modules.t
+++ b/t/10-alternate-relation-modules.t
@@ -10,7 +10,7 @@ use Test;
 
 use Red;
 
-use lib <t/lib>;
+use lib $?FILE.IO.parent(1).add('lib');
 
 use Person;
 use Post;

--- a/t/lib/Person.rakumod
+++ b/t/lib/Person.rakumod
@@ -1,3 +1,4 @@
+use v6;
 use Red;
 
 model Person is rw {
@@ -5,4 +6,3 @@ model Person is rw {
     has Str  $.name          is column;
     has      @.posts         is relationship({ .author-id }, model => 'Post');
 }
-

--- a/t/lib/Post.rakumod
+++ b/t/lib/Post.rakumod
@@ -1,3 +1,4 @@
+use v6;
 use Red;
 
 model Post is rw {
@@ -7,4 +8,3 @@ model Post is rw {
     has Str         $.body      is column;
     has             $.author    is relationship({ .author-id }, model => 'Person');
 }
-


### PR DESCRIPTION
When a model has 2+ positional relationships and 2 or more are defined
in the profile submitted to `.^create` then Red dies with an attempt to
find a positional accessor on `Any`. The bug is caused by scoping issue.
`FIRST` phaser doesn't create a new scope but operates withing the scope
of loop's block. Therefore any `my` declared within the phaser remains
uninitialized on 2nd repetition.