### PR TITLE
Fix for runtime application of role to model object

### DIFF
--- a/lib/MetamodelX/Red/Id.pm6
+++ b/lib/MetamodelX/Red/Id.pm6
@@ -22,11 +22,14 @@ sub id-values-attr-build(\type, | --> Hash){
 }
 
 method set-helper-attrs(Mu \type) {
-    my %attr is Set = type.^attributes>>.name;
-    unless %attr<%!___ID_VALUES___> {
-            $!id-values-attr = Attribute.new: :name<%!___ID_VALUES___>, :package(type), :type(Hash), :!has_accessor;
-            $!id-values-attr.set_build: &id-values-attr-build;
-            type.^add_attribute: $!id-values-attr;
+    my %attr = type.^attributes.map( -> $a { $a.name => $a }).Hash;
+    if %attr<%!___ID_VALUES___> -> $a {
+        $!id-values-attr //= $a;
+    }
+    else {
+        $!id-values-attr = Attribute.new: :name<%!___ID_VALUES___>, :package(type), :type(Hash), :!has_accessor;
+        $!id-values-attr.set_build: &id-values-attr-build;
+        type.^add_attribute: $!id-values-attr;
     }
 }
 

--- a/lib/MetamodelX/Red/Model.pm6
+++ b/lib/MetamodelX/Red/Model.pm6
@@ -131,6 +131,7 @@ method new(|c) {
 
 #| Compose
 method compose(Mu \type) {
+
     self.set-helper-attrs: type;
 
     type.^prepare-relationships;
@@ -287,7 +288,7 @@ method add-column(::T Red::Model:U \type, Red::Attr::Column $attr) {
             self.add-reference: $name, $attr.column
         }
         self.add-comparate-methods(T, $attr);
-        if $attr.has_accessor {
+        if $attr.has_accessor && !T.^can($name) {
             if type.^rw or $attr.rw {
                 $attr does role :: { method rw { True } };
                 T.^add_multi_method: $name, my method (Red::Model:D:) is rw {

--- a/t/59-runtime-role.t
+++ b/t/59-runtime-role.t
@@ -1,0 +1,61 @@
+#!/usr/bin/env raku
+
+use Test;
+
+use Red;
+
+my $*RED-DEBUG          = $_ with %*ENV<RED_DEBUG>;
+my $*RED-DB             = database "SQLite", |(:database($_) with %*ENV<RED_DATABASE>);
+
+subtest {
+
+    my role FooMixin {
+        method zub() {
+        }
+    }
+
+
+    model BarMixin {
+        has Int $.id is serial;
+    }
+
+    BarMixin.^create-table;
+
+    my $bar = BarMixin.^create;
+
+    my $bar-id = $bar.id;
+
+    lives-ok { $bar.^mixin(FooMixin) }, '^mixin lived';
+
+    does-ok $bar,FooMixin, 'role got applied';
+
+    lives-ok { is $bar.id, $bar-id, "id is correct" }, "get attribute lives";
+}, "runtime add role to row with '^mixin'";
+
+subtest {
+
+    my role FooDoes {
+        method zub() {
+        }
+    }
+
+
+    model BarDoes {
+        has Int $.id is serial;
+    }
+
+    BarDoes.^create-table;
+
+    my $bar = BarDoes.^create;
+
+    my $bar-id = $bar.id;
+
+    lives-ok { $bar does FooDoes }, 'does lived';
+
+    does-ok $bar,FooDoes, 'role got applied';
+
+    lives-ok { is $bar.id, $bar-id, "id is correct" }, "get attribute lives";
+}, "runtime add role to row with 'does'";
+
+done-testing();
+# vim: ft=raku


### PR DESCRIPTION
When a role is applied to an object with either 'does' or '.^mixin' the
compose method of the Meta object will be called to mix in any new
methods or attributes that the role provides, so the compose of the
MetamodelX::Red::Model must avoid creating duplicate accessors for the
model's columns.

Additionally when a role is applied with `does` the BUILD_LEAST_DERIVED
is called on the resulting composed object, resulting in the 'TWEAK' or
'BUILD' being called with no argument so the generated TWEAK added by
the MetamodelX::Red::Dirtable needs to deal with there already being
column data in the object and not overwriting that.

This fixes #478