### PR TITLE
Fix the interaction between `order by` and `group by`

### DIFF
--- a/lib/Red/Driver/CommonSQL.pm6
+++ b/lib/Red/Driver/CommonSQL.pm6
@@ -431,9 +431,9 @@ multi method translate(Red::AST::Select $ast, $context?, :$gambi) {
     }{
         "\nWHERE\n{ .indent: 3 }" with $where
     }{
-        "\nORDER BY\n{ .indent: 3 }" with $order
-    }{
         "\nGROUP BY\n{ .indent: 3 }" with $group
+    }{
+        "\nORDER BY\n{ .indent: 3 }" with $order
     }{
         "\nLIMIT $_" with $limit
     }{

--- a/t/99-group-sort.t
+++ b/t/99-group-sort.t
@@ -1,0 +1,22 @@
+use Test;
+use Red;
+
+model TestModel {
+    has Str $.name is column;
+    has Int $.count is column;
+}
+
+my $*RED-DEBUG          = $_ with %*ENV<RED_DEBUG>;
+my $*RED-DEBUG-RESPONSE = $_ with %*ENV<RED_DEBUG_RESPONSE>;
+my @conf                = (%*ENV<RED_DATABASE> // "SQLite").split(" ");
+my $driver              = @conf.shift;
+my $*RED-DB             = database $driver, |%( @conf.map: { do given .split: "=" { .[0] => .[1] } } );
+
+schema(TestModel).drop;
+TestModel.^create-table;
+
+my $b = TestModel.^all.sort(*.count).classify(*.name).Bag;
+
+pass('sort + classify should produce correct SQL');
+
+done-testing;


### PR DESCRIPTION
In SQL, a `GROUP BY` must come before the `ORDER BY`. Currently, Red produces them in the wrong order.

I've added a test and fix the cause of the problem.