### PR TITLE
Propagate :$name provided to the join-model to underlying join method

### DIFF
--- a/lib/Red/ResultSeq.pm6
+++ b/lib/Red/ResultSeq.pm6
@@ -403,7 +403,7 @@ multi method join(Str() $sep) {
 }
 
 #| Create a custom join (SQL join)
-method join-model(Red::Model \model, &on, :$name = "{ self.^name }_{ model.^name }", *%pars where { .elems == 0 || ( .elems == 1 && so .values.head ) }) {
+method join-model(Red::Model \model, &on, :$name = "{ self.^shortname }_{ model.^shortname }", *%pars where { .elems == 0 || ( .elems == 1 && so .values.head ) }) {
     do with self.obj {
         my $filter = do given what-does-it-do(&on.assuming($_), model) {
             do if [eqv] .values {
@@ -423,7 +423,7 @@ method join-model(Red::Model \model, &on, :$name = "{ self.^name }_{ model.^name
         }
         model.^all.where: $filter
     } else {
-        self.of.^join(model, &on, |%pars).^all.clone: :$!chain
+        self.of.^join(model, &on, :$name,  |%pars).^all.clone: :$!chain
     }
 }
 

--- a/t/65-join-model.t
+++ b/t/65-join-model.t
@@ -1,0 +1,31 @@
+#!/usr/bin/env raku
+
+use Test;
+
+use Red;
+
+
+my $*RED-FALLBACK       = False;
+my $*RED-DEBUG          = $_ with %*ENV<RED_DEBUG>;
+my $*RED-DEBUG-RESPONSE = $_ with %*ENV<RED_DEBUG_RESPONSE>;
+my @conf                = (%*ENV<RED_DATABASE> // "SQLite").split(" ");
+my $driver              = @conf.shift;
+my $*RED-DB             = database $driver, |%( @conf.map: { do given .split: "=" { .[0] => .[1] } } );
+
+model Bar::Foo is table('foo') {
+	has Str $.a is column;
+	has Str $.b is column;
+	has Str $.c is column;
+	has Date $.foo-date is column = Date.today;
+}
+
+schema(Bar::Foo).drop.create;
+
+my Date $today = Date.today;
+my Date $yesterday = Date.today.earlier(days => 1);
+
+lives-ok {
+    Bar::Foo.^rs.grep(*.foo-date eq $yesterday ).join-model( Bar::Foo, -> $a, $b {  $a.a == $b.a   && $a.b == $b.b && $a.c == $b.c  && $b.foo-date eq $today }, name => "foo_2" ).elems
+}, "join-model with nested package name";
+
+done-testing;


### PR DESCRIPTION
This provides a way of overcoming the invalid alias generated for
multi-level packaged models as described in #492

This also changes the default of '$name' to use the 'shortname' rather
than the fully qualified name so as to provide something usable, this
can probably be improved.