### PR TITLE
Make operator candidates for Enumeration RHS

### DIFF
--- a/lib/Red/Operators.pm6
+++ b/lib/Red/Operators.pm6
@@ -154,6 +154,11 @@ multi infix:<==>(Red::AST $a, Numeric() $b is readonly) is export {
     Red::AST::Eq.new: $a, ast-value($b), :cast<num>
 }
 
+#| X == Y # Where LHS is AST and RHS is Enumeration
+multi infix:<==>(Red::AST $a, Enumeration $b) is export {
+    Red::AST::Eq.new: $a, ast-value($b.value), :cast<num>, :bind-right
+}
+
 #| X == Y # Where X is castable to Numeric and writable
 multi infix:<==>(Numeric() $a is rw, Red::AST $b) is export {
     Red::AST::Eq.new: ast-value($a), $b, :cast<num>, :bind-left
@@ -272,6 +277,11 @@ multi infix:<eq>(Red::AST $a where .returns ~~ DateTime, Date $b) is export {
 #| X eq Y # Where both are AST that returns Str
 multi infix:<eq>(Red::AST $a where .returns ~~ Str, Red::AST $b where .returns ~~ Str) is export {
     Red::AST::Eq.new: $a, $b, :cast<str>;
+}
+
+#| X eq Y # Where LHS is an AST and RHS is Enumeration
+multi infix:<eq>(Red::AST $a, Enumeration $b) is export {
+    Red::AST::Eq.new: $a, ast-value($b.value), :cast<str>, :bind-right
 }
 
 #| X ne Y # Where Y is castable to Str and writable
@@ -872,7 +882,7 @@ multi infix:<in>(Red::AST $a, PositionalNotResultSeq $b ) is export {
 
 #| X ⊂ Y # Where Y is a positional but not a ResultSeq
 multi infix:<⊂>(Red::AST $a, PositionalNotResultSeq $b ) is export {
-    Red::AST::In.new: $a, ast-value($b);
+    Red::AST::In.new: $a, ast-value($b.map(-> $v { $v ~~ Enumeration ?? $v.value !! $v }).List);
 }
 
 #| X (<) Y # Where Y is a positional but not a ResultSeq

--- a/t/66-enums.t
+++ b/t/66-enums.t
@@ -1,0 +1,38 @@
+#!/usr/bin/env raku
+
+use Test;
+use Red:api<2> <refreshable>;
+
+my $*RED-FALLBACK       = False;
+my $*RED-DEBUG          = $_ with %*ENV<RED_DEBUG>;
+my $*RED-DEBUG-RESPONSE = $_ with %*ENV<RED_DEBUG_RESPONSE>;
+my @conf                = (%*ENV<RED_DATABASE> // "SQLite").split(" ");
+my $driver              = @conf.shift;
+my $*RED-DB             = database $driver, |%( @conf.map: { do given .split: "=" { .[0] => .[1] } } );
+
+enum E <a b c>;
+enum V ( d => "a", e => "b", f => "c" );
+
+model M is rw {
+    has UInt $.id is serial;
+    has E    $.my-e is column;
+}
+
+model N is rw {
+    has UInt $.id is serial;
+    has V    $.my-v is column;
+}
+schema(M, N).drop.create;
+
+M.^create(my-e => a);
+N.^create(my-v => d);
+
+is M.^all.grep(*.my-e == a).elems, 1, "Enum column, integer enum RHS ==";
+is M.^all.grep(*.my-e ⊂ [a]).elems, 1, "Enum column, single item integer enum list IN";
+is M.^all.grep(*.my-e ⊂ (a, b)).elems, 1, "Enum column, list of integer enums RHS IN";
+
+is N.^all.grep(*.my-v eq d).elems, 1, "Enum column, string enum RHS eq";
+is N.^all.grep(*.my-v ⊂ [d]).elems, 1, "Enum column, single item string enum list IN";
+is N.^all.grep(*.my-v ⊂ (d, e)).elems, 1, "Enum column, list of string enums RHS IN";
+
+done-testing();


### PR DESCRIPTION
It would seem that there are more specific core operator candidates
for '==' and 'eq' with an Enumeration RHS so these won't be handled by
Red leading to suprising results.

Only implemented for equality operators (and IN,) as I'm not sure
whether any other operators make sense.

Fixes the #495