### PR TITLE
Allow for aliases in Red::Schema

### DIFF
--- a/t/51-schema.t
+++ b/t/51-schema.t
@@ -56,5 +56,14 @@ isa-ok $s3, Red::Schema;
 is $s3.model('Z').^name, "Post", "model() using alias";
 is $s3.model('X').^name, "Person", "model() using alias";
 
+# Test using type objects from the previous schema
+my $s4 = schema( Z => $s3.Z, X => $s3.X);
+
+isa-ok $s4, Red::Schema;
+is $s4.model('Z').^name, "Post", "model() using alias - type object";
+is $s4.model('X').^name, "Person", "model() using alias - type object";
+
+
+
 
 done-testing;

--- a/t/51-schema.t
+++ b/t/51-schema.t
@@ -50,5 +50,11 @@ dies-ok {
     $s1.Person.^create: :name<bla>;
 }
 
+my $s3 = schema( Z => 'Post', X => 'Person');
+
+isa-ok $s3, Red::Schema;
+is $s3.model('Z').^name, "Post", "model() using alias";
+is $s3.model('X').^name, "Person", "model() using alias";
+
 
 done-testing;


### PR DESCRIPTION
In a large application one might arrange the model classes in
multi-level packages to distinguish them from other classes in the
application (e.g. Org::AppName::Model::ModelName, ) and it might be
unwieldy (and difficult to remember,) to use the full name everywhere.

This provides for a Pair-wise `schema` so that an alias for the model
can be conveniently provided and used to retrieve the model.

Also provide a `model` method as an alternative to the `FALLBACK` as
using the fallback method may be confusing for a multi-level packaged
model.