### PR TITLE
Really create a new connection for transaction in Pg

### DIFF
--- a/lib/Red/Do.pm6
+++ b/lib/Red/Do.pm6
@@ -129,9 +129,10 @@ multi red-do(
         Bool :$transaction! where so *,
         *%pars where *.none.key eq "with"
 ) is export {
-    KEEP get-RED-DB.commit;
-    UNDO get-RED-DB.rollback;
-    red-do |@blocks, :$async, |%pars, :with(get-RED-DB.begin);
+    my $conn = get-RED-DB.begin;
+    KEEP $conn.commit;
+    UNDO $conn.rollback;
+    red-do |@blocks, :$async, |%pars, :with($conn);
 }
 
 #| Receives list of pairs with connection name and block

--- a/lib/Red/Driver/Pg.pm6
+++ b/lib/Red/Driver/Pg.pm6
@@ -25,6 +25,11 @@ submethod TWEAK() {
     $!dbh //= DB::Pg.new: conninfo => "{ "user=$_" with $!user } { "password=$_" with $!password } { "host=$_" with $!host } { "port=$_" with $!port } { "dbname=$_" with $!dbname }";
 }
 
+method new-connection {
+    self.WHAT.new: |self.^attributes.grep( *.name ne '$!dbh').map({ .name.substr(2) => .get_value: self }).Hash
+}
+
+
 method wildcard { "\${ ++$*bind-counter }" }
 
 multi method translate(Red::Column $_, "column-auto-increment") {}


### PR DESCRIPTION
Previously when the 'begin' created a new Red::Driver::Pg it was copying
the existing '$!dbh' which meant that it was sharing the same
'connection pool' from the DB::Pg, which in turn means that under a
moderately high level of concurrency there is a chance that any
statement within the "transaction" may actually get a different
"connection" (DB::Pg::Database instance,) and so may actually be in
separate transactions, thus for instance an insert with foreign key for
a row created in a previous statement may fail.

This change forces the creation of a new 'DB::Pg' for the new Driver and
ensures that all the statements in the transation will all use the same
driver instance.

This is to address #503 in the simplest way possible.