### PR TITLE
Fix sporadic warnings

### DIFF
--- a/lib/Red/ResultSeq.pm6
+++ b/lib/Red/ResultSeq.pm6
@@ -61,7 +61,7 @@ method create-comment-to-caller is hidden-from-sql-commenting {
 
 #| Add a comment to SQL query
 sub comment-sql(:$meth-name, :$file, :$block, :$line) {
-    "method '$meth-name' called at: { $file } #{ $line }"
+    "method '{ $meth-name // '<anon>' }' called at: { $file // '<none>' } #{ $line // '' }"
 }
 
 #| The type of the ResultSeq


### PR DESCRIPTION
I couldn't quite get to the root cause of this but I'm getting

	Use of uninitialized value of type Any in string context.
	Methods .^name, .raku, .gist, or .say can be used to stringify it to something meaningful.
	  in sub comment-sql at /home/jonathan/.raku/sources/753B239794CDB8666CFB224C5FF51639226449BE (Red::ResultSeq) line 64
	Use of uninitialized value of type Any in string context.
	Methods .^name, .raku, .gist, or .say can be used to stringify it to something meaningful.
	  in sub comment-sql at /home/jonathan/.raku/sources/753B239794CDB8666CFB224C5FF51639226449BE (Red::ResultSeq) line 64

Sporadically in some tests, so this is just a sticking plaster until I
can find what provokes it, and why it only happens some of the time.