### PR TITLE
Ensure use attr name not column name in new-from-data

### DIFF
--- a/t/70-conflicting-column-attribute.t
+++ b/t/70-conflicting-column-attribute.t
@@ -1,0 +1,45 @@
+#!/usr/bin/env raku
+
+use Red;
+use Test;
+
+my $*RED-DEBUG          = $_ with %*ENV<RED_DEBUG>;
+my $*RED-DEBUG-RESPONSE = $_ with %*ENV<RED_DEBUG_RESPONSE>;
+my @conf                = (%*ENV<RED_DATABASE> // "SQLite").split(" ");
+my $driver              = @conf.shift;
+my $*RED-DB             = database $driver, |%( @conf.map: { do given .split: "=" { .[0] => .[1] } } );
+
+model A {
+    has Str $.id is id;
+}
+
+model B {
+    has Int $.id is serial;
+    has Str $.a-id is column({ name => 'a', model-name => 'A', column-name => 'id' });
+    has     $.a    is relationship({ .a-id }, model => 'A');
+    has Int $.c-id is referencing(model => 'C', column => 'id' );
+    has     $.c is relationship({ .c-id }, model => 'C');
+}
+
+model C {
+    has Int $.id is serial;
+    has DateTime $.d is column = DateTime.now;
+    has     @.bs is relationship({ .c-id }, model => 'B' );
+}
+
+A.^create-table;
+C.^create-table;
+B.^create-table;
+
+A.^create( id => 'FOO');
+
+my $c = C.^create;
+
+my $b;
+
+lives-ok { $b = B.^new-from-data: { a => 'FOO', c_id => $c.id } }, "new-from-data with column names";
+is $b.a-id, 'FOO', "got the FK in the attribute with the conflicting column name";
+is $b.c-id, $c.id, "got the other FK right too";
+
+done-testing;
+# vim: ft=raku


### PR DESCRIPTION
If there was a column defined in a model where the DB column differs
from the attribute name, and the DB column name is the same as another
attribute in the model then `new-from-data` would pass the DB column
name to the constructor of the model class rather than the attribute
name that corresponds to that column which would lead either to a
failure if the attribute with that name was a relation (it would get a
plain value rather than a model object,) or the wrong attribute being
populated with the value.

This appears to only afflict Pg where the data from the insert with
`RETURNING *` is used to create the object returned by `create` whereas
for SQLite the object is loaded from the DB.

The test simulates the Pg behaviour by calling `new-from-data` directly.

Fixes #510