### PR TITLE
Fix DateTime roundtrip on Pg

### DIFF
--- a/lib/Red/Driver/Pg.pm6
+++ b/lib/Red/Driver/Pg.pm6
@@ -200,6 +200,7 @@ multi method default-type-for(Red::Column $ where .attr.type ~~ UUID           -
 multi method default-type-for(Red::Column $                                    --> Str:D) {"varchar(255)"}
 
 multi method inflate(Str $value, DateTime :$to!) { DateTime.new: $value }
+multi method deflate(DateTime $value) { ~$value.utc }
 
 multi method map-exception(DB::Pg::Error::FatalError $x where .?message ~~ /"duplicate key value violates unique constraint " \"$<field>=(\w+)\"/) {
     X::Red::Driver::Mapped::Unique.new:


### PR DESCRIPTION
Since currently a `timestamp` (without timezone) is used as the column type
of DateTime columns, Pg silently strips any trailing timezone info of the
given DateTime string. Thus it's necessary to convert DateTime values to
UTC prior to serializing them, to not wrongly change the point in time.