### PR TITLE
Alter func translation so column names don't get aliases

### DIFF
--- a/lib/Red/Driver/CommonSQL.pm6
+++ b/lib/Red/Driver/CommonSQL.pm6
@@ -472,7 +472,7 @@ multi method translate(Red::AST::DateTimeFunction $_, $context?) {
 multi method translate(Red::AST::Function $_, $context?) {
     my @bind;
     "{ .func }({ .args.map({
-        my ($s, @b) := do given self.translate: $_, $context { .key, .value }
+        my ($s, @b) := do given self.translate: $_, 'func' { .key, .value }
         @bind.append: @b;
         $s
     }).join: ", " })" => @bind


### PR DESCRIPTION
If the function is used in a subselect with a Red::Column argument it
was using the 'select' candidate for the translate of the args which was
in turn adding the 'as' alias to the attribute name.  This is a syntax
error in at least Pg.

This addresses a problem found in #514 