### PR TITLE
Fixes constucting an enum column from another column

### DIFF
--- a/lib/Red/Model.pm6
+++ b/lib/Red/Model.pm6
@@ -20,7 +20,7 @@ method new(*%pars) is hidden-from-backtrace {
     for @columns -> \col {
         my $name = col.name.substr: 2;
         if %pars{$name}:exists {
-            my \value = %pars{$name};
+            my \value = %pars{$name}<>;
             my $is-rtype = col.type.?is-red-type(col.type);
             die X::TypeCheck::Assignment.new(symbol => col.name, got => value, expected => col.type)
                 unless ( !$is-rtype && value ~~ col.type ) || ( $is-rtype && col.type.red-type-accepts: value.WHAT );

--- a/t/73-enum-reassign.t
+++ b/t/73-enum-reassign.t
@@ -1,0 +1,17 @@
+use Test;
+use Red;
+
+enum E <E1>;
+
+model M {
+    has E $.e is column is rw;
+}
+my M $m1 .= new: e => E1;
+
+my M $m2;
+lives-ok {
+    $m2 .= new: e => $m1.e;
+    is $m2.e, E1;
+}
+
+done-testing


### PR DESCRIPTION
Fixes the following:

enum E <E1>;
model M { has E $.e is column is rw; }
my M $m1 .= new: e => E1;
my M $m2 .= new: e => $m1.e; # doesn't error anymore