### PR TITLE
Change default SQL type for Raku `Str` from `varchar` to `text`

### DIFF
--- a/lib/Red/Driver/CommonSQL.rakumod
+++ b/lib/Red/Driver/CommonSQL.rakumod
@@ -974,7 +974,7 @@ multi method default-type-for-type(Instant  --> Str:D) {"real"}
 multi method default-type-for-type(DateTime --> Str:D) {"varchar(32)"}
 multi method default-type-for-type(Duration --> Str:D) {"interval"}
 multi method default-type-for-type(Mu       --> Str:D) {"varchar(255)"}
-multi method default-type-for-type(Str      --> Str:D) {"varchar(255)"}
+multi method default-type-for-type(Str      --> Str:D) {"text"}
 multi method default-type-for-type(Int      --> Str:D) {"integer"}
 multi method default-type-for-type(Bool     --> Str:D) {"boolean"}
 multi method default-type-for-type(UUID     --> Str:D) {"varchar(36)"}

--- a/t/12-roles.rakutest
+++ b/t/12-roles.rakutest
@@ -14,7 +14,7 @@ model Ble does Bla {}
 
 $*RED-DB.when: :once, :return[], qq:to/EOSQL/;
     CREATE TABLE "ble" (
-        a varchar(255) NOT NULL
+        a text NOT NULL
     )
 EOSQL
 
@@ -24,8 +24,8 @@ model Bli does Bla { has Str $.b is column }
 
 $*RED-DB.when: :once, :return[], qq:to/EOSQL/;
     CREATE TABLE "bli" (
-        a varchar(255) NOT NULL,
-        b varchar(255) NOT NULL
+        a text NOT NULL,
+        b text NOT NULL
     )
 EOSQL
 
@@ -96,7 +96,7 @@ model Foo does Bar[:opt-in] does Baz {
 $*RED-DB.when: :once, :return[], q:to/EOSQL/;
     create table "foo"(
         id integer not null primary key autoincrement,
-        a varchar ( 255 ) not null,
+        a text not null,
         b integer not null,
         c real not null
     )


### PR DESCRIPTION
Pretty self explanatory, it seemed like a marginal change and it's an easy win