### PR TITLE
Don't emit "FOR UPDATE .." On SQLite

### DIFF
--- a/lib/Red/Driver/CommonSQL.rakumod
+++ b/lib/Red/Driver/CommonSQL.rakumod
@@ -514,16 +514,22 @@ multi method translate(Red::AST::Select $ast, $context?, :$gambi) {
         "\nOFFSET $_" with $offset
     }{
         do with $ast.for // $*red-subselect-for {
-            "\nFOR {
-                when UPDATE {
-                    "UPDATE"
-                }
-                when SKIP_LOCKED {
-                    "UPDATE SKIP LOCKED"
-                }
-            }"
+            self.translate($_);
         }
     }" => @bind
+}
+
+multi method translate(Red::LockType $lock-type --> Str ) {
+    given $lock-type {
+        "\nFOR {
+            when UPDATE {
+                "UPDATE"
+            }
+            when SKIP_LOCKED {
+                "UPDATE SKIP LOCKED"
+            }
+        }"
+     }
 }
 
 multi method translate(Red::AST::StringFunction $_, $context?) {
@@ -805,7 +811,7 @@ multi method translate(Red::Column $_, "column-default")        {
     my ($str, @bind);
     :(:key($str), :value(@bind)) := self.translate: do given .default.($_) {
         do if $_ !~~ Red::AST {
-            .&ast-value 
+            .&ast-value
         } else {
             $_
         }

--- a/lib/Red/Driver/SQLite.rakumod
+++ b/lib/Red/Driver/SQLite.rakumod
@@ -161,6 +161,10 @@ multi method translate(Red::AST::Value $_ where { .type ~~ Pair and .value.key ~
 
 multi method translate(Red::AST::Minus $ast, "multi-select-op") { "EXCEPT" => [] }
 
+multi method translate(Red::LockType $lock-type --> Str ) {
+    ''
+}
+
 method comment-on-same-statement { True }
 
 #multi method default-type-for(Red::Column $ where .attr.type ~~ Mu             --> Str:D) {"varchar(255)"}

--- a/t/81-resultset-skip-locked.rakutest
+++ b/t/81-resultset-skip-locked.rakutest
@@ -1,0 +1,25 @@
+use Test;
+use Red;
+
+model Foo {
+    has Int $.bar is serial;
+    has Str $.foo is column;
+}
+
+my $*RED-DEBUG          = $_ with %*ENV<RED_DEBUG>;
+my $*RED-DEBUG-RESPONSE = $_ with %*ENV<RED_DEBUG_RESPONSE>;
+my @conf                = (%*ENV<RED_DATABASE> // "SQLite").split(" ");
+my $driver              = @conf.shift;
+my $*RED-DB             = database $driver, |%( @conf.map: { do given .split: "=" { .[0] => val .[1] } } );
+
+schema(Foo).drop;
+Foo.^create-table;
+
+Foo.^create: foo => "babaa";
+
+my @rows;
+lives-ok { @rows = Foo.^rs.skip-locked.all }, 'with skip-locked';
+
+is @rows.elems, 1, "got the right number of rows";
+
+done-testing


### PR DESCRIPTION
Rather than just ignore it like it does for other things it doesn't implement, SQLite throws an error with 'FOR UPDATE' on a select statement.

This just over-rides with an implementation that doesn't emit anything if there is a '.for'.

The test just checks it doesn't explode with .skip-update, I've confirmed the SQL generated for both Pg and SQLite visually.

Fixes the #576 