### PR TITLE
Update start.md - correct link

### DIFF
--- a/docs/tutorials/start.md
+++ b/docs/tutorials/start.md
@@ -1,7 +1,7 @@
 ## Red starter tutorial
 
 This document is an introduction tutorial which shows the most basic usage examples of Red.
-For more in-depth introduction about Red architecture visit [Red architecture](tutorials/architecture) page.
+For more in-depth introduction about Red architecture visit [Red architecture](/architecture) page.
 
 ### Models and tables
 


### PR DESCRIPTION
I noticed that on https://fco.github.io/Red/tutorials/start.html the link to the Red Architecture page contained "tutorials/" twice. This leads to a 404.