### PR TITLE
Update start.md link to relationship typo

### DIFF
--- a/docs/tutorials/start.md
+++ b/docs/tutorials/start.md
@@ -212,4 +212,4 @@ Person.^delete;
 Here, we covered basics of Red usage. Refer to Red cookbook
 for different examples without a particular order or visit the next
 tutorial in this series, related to expressing table relationships
-using Red, [here](relationships).
+using Red, [here](relationship).


### PR DESCRIPTION
At the end of this page a link is created. But instead of "relationship" as the file is called, "relationships" is used.