### PR TITLE
Update README.md to include alternative command

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ Install with (you need **rakudo 2018.12-94-g495ac7c00** or **newer**):
 
     zef install Red
 
+If the command above doesn't work, you may need to add the following flag to the install command:
+
+```
+zef install --exclude="pq:ver<5>:from<native>" Red
+```
+
+The above `--exclude` flag tells `zef` to not try and install the dependency `pq` directly as it is a native library (it's referencing `libpq`.) 
+
 SYNOPSIS
 --------
 


### PR DESCRIPTION
Adds an example of installing Red without trying to install libpq directly through zef to the README file. This is good for newcomers to Red who may be struggling to install it on their development environment.